### PR TITLE
Feature / Normalize() for Vec2, Vec3 and Vec4

### DIFF
--- a/src/include/ldk/ldk_math.h
+++ b/src/include/ldk/ldk_math.h
@@ -48,6 +48,8 @@ namespace ldk
 		Vec2& operator/=(const Vec2& other);
 
 		float magnitude();
+		
+		Vec2 normalize();
 
 		static const Vec2& one();
 
@@ -88,6 +90,8 @@ namespace ldk
 		Vec3& operator/=(const Vec3& other);
 
 		float magnitude();
+		
+		Vec3 normalize();
 
 		static const Vec3& one();
 
@@ -125,6 +129,8 @@ namespace ldk
 		Vec4& operator/=(const Vec4& other);
 
 		float magnitude();
+		
+		Vec4 normalize();
 
 		static const Vec4& one();
 

--- a/src/ldk_math.cpp
+++ b/src/ldk_math.cpp
@@ -356,7 +356,7 @@ namespace ldk
 		return sqrt(x * x + y * y + z * z + w * w);
 	}
 
-	Vec4 Vec3::normalize()
+	Vec4 Vec4::normalize()
 	{
 		Vec4 result;
 		float magnitude = sqrt(x * x + y * y + z * z + w * w);

--- a/src/ldk_math.cpp
+++ b/src/ldk_math.cpp
@@ -96,6 +96,15 @@ namespace ldk
 		return sqrt(x * x + y * y);
 	}
 
+	Vec2 Vec2::normalize()
+	{
+		Vec2 result;
+		float magnitude = sqrt(x * x + y * y);
+		result.x = this->x / magnitude;
+		result.y = this->y / magnitude;
+		return result;
+	}
+
 	const Vec2& Vec2::one()
 	{
 		return (const Vec2&)_one;
@@ -221,6 +230,16 @@ namespace ldk
 		return sqrt(x * x + y * y + z * z);
 	}
 
+	Vec3 Vec3::normalize()
+	{
+		Vec3 result;
+		float magnitude = sqrt(x * x + y * y + z * z);
+		result.x = this->x / magnitude;
+		result.y = this->y / magnitude;
+		result.z = this->z / magnitude;
+		return result;
+	}
+
 	const Vec3& Vec3::one()
 	{
 		return (const Vec3&)_one;
@@ -335,6 +354,17 @@ namespace ldk
 	float Vec4::magnitude()
 	{
 		return sqrt(x * x + y * y + z * z + w * w);
+	}
+
+	Vec4 Vec3::normalize()
+	{
+		Vec4 result;
+		float magnitude = sqrt(x * x + y * y + z * z + w * w);
+		result.x = this->x / magnitude;
+		result.y = this->y / magnitude;
+		result.z = this->z / magnitude;
+		result.w = this->w / magnitude;
+		return result;
 	}
 
 	const Vec4& Vec4::one()


### PR DESCRIPTION
Created and implemented `normalize()` function for `Vec2`, `Vec3` and `Vec4` structs.
The `normalize()` returns the correspondent unit vector of a given vector.