### PR TITLE
Rewrite the Vertex buffer abstraction

### DIFF
--- a/include/ldk/asset/mesh.h
+++ b/include/ldk/asset/mesh.h
@@ -26,7 +26,7 @@ extern "C" {
   typedef struct
   {
     LDK_DECLARE_ASSET;
-    LDKVertexBuffer   vBuffer;
+    LDKRenderBuffer*  vBuffer;
     float*            vertices;
     uint16*           indices;
     LDKHandle*        materials;

--- a/include/ldk/common.h
+++ b/include/ldk/common.h
@@ -142,8 +142,7 @@ extern "C" {
   typedef uint64_t  uint64;
   typedef uintptr_t LDKHandle;
   typedef void*     LDKWindow;
-  typedef void*     LDKVertexBuffer;
-  typedef void*     LDKIndexBuffer;
+  typedef struct LDKRenderBuffer_t LDKRenderBuffer;
 
 
   // SmallStr

--- a/include/ldk/module/renderer.h
+++ b/include/ldk/module/renderer.h
@@ -23,17 +23,10 @@
 extern "C" {
 #endif
 
-
-  typedef enum
-  {
-    LDK_VERTEX_LAYOUT_NONE  = 0,  // No attributes enabled
-    LDK_VERTEX_LAYOUT_PNU   = 1,  // Position, Normal, UV
-    LDK_VERTEX_LAYOUT_PNTBU = 2,  // Position, Normal, Tangent, Binormal, UV
-  } LDKVertexLayout;
-
   LDK_API bool ldkRendererInitialize(LDKConfig* config);
   LDK_API void ldkRendererResize(uint32 width, uint32 height);
   LDK_API void ldkRendererTerminate(void);
+
 
   //
   // Shader
@@ -43,13 +36,13 @@ extern "C" {
   LDK_API bool ldkFragmentShaderCreate(const char* source, LDKShader* shader);
   LDK_API bool ldkVertexShaderCreate(const char* source, LDKShader* shader);
   LDK_API bool ldkGeometryShaderCreate(const char* source, LDKShader* shader);
-
   LDK_API void ldkShaderDestroy(LDKShader* shader);
   LDK_API bool ldkShaderProgramBind(LDKShader* shaderAsset); // Passing in NULL will unbind current Shader program
 
   //
   // Material
   //
+
   LDK_API bool ldkMaterialCreate(LDKShader* handle, LDKMaterial* out);
   LDK_API void ldkMaterialDestroy(LDKMaterial* material);
   LDK_API bool ldkMaterialParamSetInt(LDKMaterial* material, const char* name, int value);
@@ -61,6 +54,7 @@ extern "C" {
   LDK_API bool ldkMaterialParamSetTexture(LDKMaterial* handle, const char* name, LDKTexture* value);
   LDK_API bool ldkMaterialBind(LDKMaterial* material); // Passing in NULL will unbind current Material
 
+
   //
   // Texture
   //
@@ -71,19 +65,79 @@ extern "C" {
 
 
   //
-  // VertexBuffer
+  // RenderBuffer
   //
-  LDK_API LDKVertexBuffer ldkVertexBufferCreate(LDKVertexLayout layout);
-  LDK_API void ldkVertexBufferData(LDKVertexBuffer buffer, void* data, size_t size);
-  LDK_API void ldkVertexBufferSubData(LDKVertexBuffer buffer, size_t offset, void* data, size_t size);
-  LDK_API void ldkVertexBufferIndexData(LDKVertexBuffer buffer, void* data, size_t size);
-  LDK_API void ldkVertexBufferIndexSubData(LDKVertexBuffer buffer, size_t offset, void* data, size_t size);
-  LDK_API void ldkVertexBufferBind(LDKVertexBuffer buffer); // Pasing in NULL will unbind current vertexBuffer
-  LDK_API void ldkVertexBufferDestroy(LDKVertexBuffer vertexBuffer);
+
+  typedef enum
+  {
+    LDK_VERTEX_LAYOUT_NONE  = 0,  // No attributes enabled
+    LDK_VERTEX_LAYOUT_PNU   = 1,  // Position, Normal, UV
+    LDK_VERTEX_LAYOUT_PNTBU = 2,  // Position, Normal, Tangent, Binormal, UV
+  } LDKVertexLayout;
+
+  typedef enum
+  {
+    LDK_VERTEX_ATTRIB_NORMALIZE = 0x01 << 1,
+    LDK_VERTEX_ATTRIB_INSTANCE  = 0x01 << 2
+  } LDKVertexAttributeFlag;
+
+  typedef enum
+  {
+    // suggested semantic names
+    LDK_VERTEX_ATTRIBUTE_POSITION   = 0,
+    LDK_VERTEX_ATTRIBUTE_NORMAL     = 1,
+    LDK_VERTEX_ATTRIBUTE_TANGENT    = 2,
+    LDK_VERTEX_ATTRIBUTE_BINORMAL   = 3,
+    LDK_VERTEX_ATTRIBUTE_TEXCOORD0  = 4,
+    LDK_VERTEX_ATTRIBUTE_TEXCOORD1  = 5,
+    LDK_VERTEX_ATTRIBUTE_CUSTOM0    = 6,
+    LDK_VERTEX_ATTRIBUTE_CUSTOM1    = 7,
+    LDK_VERTEX_ATTRIBUTE_MATRIX0    = 8,  // it takes 4 locations
+    LDK_VERTEX_ATTRIBUTE_MATRIX1    = 12, // it takes 4 locations
+
+    // Non semantic
+    LDK_VERTEX_ATTRIBUTE0           = 0,
+    LDK_VERTEX_ATTRIBUTE1           = 1,
+    LDK_VERTEX_ATTRIBUTE2           = 2,
+    LDK_VERTEX_ATTRIBUTE3           = 3,
+    LDK_VERTEX_ATTRIBUTE4           = 4,
+    LDK_VERTEX_ATTRIBUTE5           = 5,
+    LDK_VERTEX_ATTRIBUTE6           = 6,
+    LDK_VERTEX_ATTRIBUTE7           = 7,
+    LDK_VERTEX_ATTRIBUTE8           = 8,
+    LDK_VERTEX_ATTRIBUTE9           = 9,
+    LDK_VERTEX_ATTRIBUTE10          = 10,
+    LDK_VERTEX_ATTRIBUTE11          = 11,
+    LDK_VERTEX_ATTRIBUTE12          = 12,
+    LDK_VERTEX_ATTRIBUTE13          = 13,
+    LDK_VERTEX_ATTRIBUTE14          = 14,
+    LDK_VERTEX_ATTRIBUTE15          = 15,
+
+    LDK_VERTEX_ATTRIBUTE_MAX        = 15  // The higher attribute location guaranteed to work with openGL
+  } LDKVertexAttributeSemantic;
+
+  LDK_API LDKRenderBuffer* ldkRenderBufferCreate(int numVBOs);
+  LDK_API void ldkRenderBufferDestroy(LDKRenderBuffer* rb);
+  LDK_API void ldkRenderBufferBind(const LDKRenderBuffer* rb); // passing null unbinds the current buffer
+  LDK_API void ldkVertexBufferSetAttributeMat4(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeFloat(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeInt(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeUInt(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeByte(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeUByte(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeDouble(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeShort(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetAttributeUShort(const LDKRenderBuffer* rb, uint32 index, LDKVertexAttributeSemantic semantic, uint32 count, int32 stride, const void *offset, LDKVertexAttributeFlag flag);
+  LDK_API void ldkVertexBufferSetData(const LDKRenderBuffer* rb, int32 index, size_t size, const void *data, bool stream);
+  LDK_API void ldkVertexBufferSetSubData(const LDKRenderBuffer* rb, int32 index, int32 offset, size_t size, const void *data);
+  LDK_API void ldkIndexBufferSetData(LDKRenderBuffer* rb, size_t size, const void *data, bool stream);
+  LDK_API void ldkIndexBufferSetSubData(LDKRenderBuffer* rb, int32 offset, size_t size, const void *data);
+
 
   //
   // Rendering
   //
+
   LDK_API void ldkRenderMesh(LDKMesh* mesh);
   LDK_API void ldkRendererCameraSet(LDKCamera* camera);
   LDK_API void ldkRendererClearColor(LDKRGB color);

--- a/runtree/assets/default.shader
+++ b/runtree/assets/default.shader
@@ -25,18 +25,11 @@
 // Vertes Shader
 //
 
-
 #ifdef LDK_COMPILE_VETEX_SHADER
-
-#define LDK_VERTEX_ATTRIBUTE_POSITION layout (location = 0) in
-#define LDK_VERTEX_ATTRIBUTE_NORMAL   layout (location = 1) in
-#define LDK_VERTEX_ATTRIBUTE_TANGENT  layout (location = 2) in
-#define LDK_VERTEX_ATTRIBUTE_BINORMAL layout (location = 3) in
-#define LDK_VERTEX_ATTRIBUTE_TEXCOORD layout (location = 4) in
 
 LDK_VERTEX_ATTRIBUTE_POSITION  vec3 vPosition;
 LDK_VERTEX_ATTRIBUTE_NORMAL    vec3 vNormal;
-LDK_VERTEX_ATTRIBUTE_TEXCOORD  vec2 vTexcoord;
+LDK_VERTEX_ATTRIBUTE_TEXCOORD0  vec2 vTexcoord;
 
 out vec2 fragTexCoord;
 

--- a/src/asset/material.c
+++ b/src/asset/material.c
@@ -1,9 +1,9 @@
 #include "ldk/asset/material.h"
 #include "ldk/asset/texture.h"
 #include "ldk/asset/image.h"
-#include "ldk/common.h"
 #include "ldk/module/asset.h"
 #include "ldk/module/renderer.h"
+#include "ldk/common.h"
 #include "ldk/os.h"
 #include <stdlib.h>
 #include <string.h>

--- a/src/asset/mesh.c
+++ b/src/asset/mesh.c
@@ -1,7 +1,7 @@
-#include "ldk/module/asset.h"
 #include "ldk/asset/mesh.h"
-#include "ldk/os.h"
+#include "ldk/module/asset.h"
 #include "ldk/module/renderer.h"
+#include "ldk/os.h"
 #include <string.h>
 #include <stdlib.h>
 
@@ -337,9 +337,15 @@ bool ldkAssetMeshLoadFunc(const char* path, LDKAsset asset)
     ldkOsMemoryFree(mesh);
   }
 
-  mesh->vBuffer = ldkVertexBufferCreate(LDK_VERTEX_LAYOUT_PNU);
-  ldkVertexBufferData(mesh->vBuffer, (void*) mesh->vertices, vertexBufferSize);
-  ldkVertexBufferIndexData(mesh->vBuffer, (void*) mesh->indices, indexBufferSize);
+
+  const int32 stride = (int32) (8 * sizeof(float));
+  mesh->vBuffer = ldkRenderBufferCreate(1);
+  ldkVertexBufferSetAttributeFloat(mesh->vBuffer, 0, LDK_VERTEX_ATTRIBUTE_POSITION, 3, stride, 0, 0);
+  ldkVertexBufferSetAttributeFloat(mesh->vBuffer, 0, LDK_VERTEX_ATTRIBUTE_NORMAL, 3, stride, (const void*) (3 * sizeof(float)), 0);
+  ldkVertexBufferSetAttributeFloat(mesh->vBuffer, 0, LDK_VERTEX_ATTRIBUTE_TEXCOORD0, 2, stride, (const void* )(6 * sizeof(float)), 0);
+  ldkVertexBufferSetData(mesh->vBuffer, 0, vertexBufferSize, mesh->vertices, false);
+  ldkIndexBufferSetData(mesh->vBuffer, indexBufferSize, mesh->indices, false);
+  ldkRenderBufferBind(NULL);
 
   return true;
 }
@@ -351,6 +357,6 @@ void ldkAssetMeshUnloadFunc(LDKAsset asset)
   ldkOsMemoryFree(mesh->materials);
   ldkOsMemoryFree(mesh->indices);
   ldkOsMemoryFree(mesh->surfaces);
-  ldkVertexBufferDestroy(mesh->vBuffer);
+  ldkRenderBufferDestroy(mesh->vBuffer);
   ldkOsMemoryFree(mesh);
 }

--- a/src/module/gl_renderer.c
+++ b/src/module/gl_renderer.c
@@ -58,7 +58,7 @@ static struct
 
 typedef enum
 {
-  LDK_RENDER_OBJECT_STATIC_MESH
+  LDK_RENDER_OBJECT_STATIC_OBJECT
 }  LDKRenderObjectType;
 
 typedef struct
@@ -1019,7 +1019,7 @@ void ldkRendererCameraSet(LDKCamera* camera)
 void ldkRendererAddStaticObject(LDKStaticObject* entity)
 {
   LDKRenderObject* ro = (LDKRenderObject*) ldkArenaAllocate(&internal.bucketROStaticMesh, sizeof(LDKRenderObject));
-  ro->type = LDK_RENDER_OBJECT_STATIC_MESH;
+  ro->type = LDK_RENDER_OBJECT_STATIC_OBJECT;
   ro->staticMesh = entity;
 }
 
@@ -1077,7 +1077,7 @@ void ldkRendererRender(float deltaTime)
 
   for(uint32 i = 0; i < count; i++)
   {
-    LDK_ASSERT(ro->type == LDK_RENDER_OBJECT_STATIC_MESH);
+    LDK_ASSERT(ro->type == LDK_RENDER_OBJECT_STATIC_OBJECT);
     internalRenderMesh(ro->staticMesh);
     ro++;
   }


### PR DESCRIPTION
Created a more flexible low level API for creating, defining and interacting with render buffers

- A Render buffer may or may not have an index buffer
- A Render buffer may have multiple vertex buffers
- Each vertex buffer may declare attributes of type byte, unsigned byte, int, unsigned int, short, unsigned short, float, double and Mat4 (4 floats)
- Vertex buffer attributes can be marked as "instanced". This will cause them to be indexed by instance, instead of per vertex.